### PR TITLE
Make plugin extensible to other test types

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,1 @@
+((nil . ((cider-clojure-cli-global-options . "-A:test"))))

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,0 +1,2 @@
+#!/bin/bash
+clojure -A:test -m kaocha.runner "$@"

--- a/src/speculative_kaocha/plugin.clj
+++ b/src/speculative_kaocha/plugin.clj
@@ -10,11 +10,15 @@
 
 (defplugin ::instrument
   (pre-test [test test-plan]
-            (when (and (test-suite? test)
-                       (not (::no-instrument test)))
-              (instrument))
-            test)
+    (let [suite? (into #{}
+                       (map :kaocha.testable/id)
+                       (:kaocha.test-plan/tests test-plan))]
+      (when (and (suite? (:kaocha.testable/id test))
+                 (not (::no-instrument test)))
+        (instrument)))
+    test)
+
   (post-test [test test-plan]
-             (when (test-suite? test)
-               (unstrument))
-             test))
+    (when (test-suite? test)
+      (unstrument))
+    test))


### PR DESCRIPTION
When the test types are hard coded, the plugin is guaranteed not to work with
future or third party types. Instead find the current test suites in the test
plan.